### PR TITLE
Add 2 new methods from Composer 2 PluginInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     },
     "require": {
-        "composer-plugin-api": "^1.1",
+        "composer-plugin-api": "^1.1 | ^2.0",
         "magento/framework": "*"
     },
     "require-dev": {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -42,6 +42,18 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $this->io = $io;
     }
 
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+        // https://getcomposer.org/upgrade/UPGRADE-2.0.md
+        // Plugins implementing EventSubscriberInterface will be deregistered from the EventDispatcher
+        // automatically when being deactivated, nothing to do there.
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+        // Nothing to uninstall
+    }
+
     public static function getSubscribedEvents()
     {
         return [


### PR DESCRIPTION
All Composer plugins used by Magento should be upgraded to support Composer 2.0 - see https://github.com/magento/community-features/issues/302